### PR TITLE
Parse meta_all before meta

### DIFF
--- a/common/src/main/java/me/lucko/luckperms/placeholders/LPPlaceholderProvider.java
+++ b/common/src/main/java/me/lucko/luckperms/placeholders/LPPlaceholderProvider.java
@@ -91,14 +91,15 @@ public class LPPlaceholderProvider implements PlaceholderProvider {
 
         builder.addStatic("suffix", (player, user, userData, queryOptions) -> Strings.nullToEmpty(userData.getMetaData(queryOptions).getSuffix()));
 
-        builder.addDynamic("meta", (player, user, userData, queryOptions, node) -> {
-            String value = userData.getMetaData(queryOptions).getMetaValue(node);
-            return value == null ? "" : value;
-        });
-
+        // meta_all needs to go before meta because they both share the same prefix
         builder.addDynamic("meta_all", (player, user, userData, queryOptions, node) -> {
             List<String> values = userData.getMetaData(queryOptions).getMeta().getOrDefault(node, ImmutableList.of());
             return values.isEmpty() ? "" : String.join(", ", values);
+        });
+
+        builder.addDynamic("meta", (player, user, userData, queryOptions, node) -> {
+            String value = userData.getMetaData(queryOptions).getMetaValue(node);
+            return value == null ? "" : value;
         });
 
         builder.addDynamic("prefix_element", (player, user, userData, queryOptions, element) -> {


### PR DESCRIPTION
Currently, the `meta_all` placeholder can never work because it's being parsed as a single meta placeholder starting with "all" in its key. (i.e., `luckperms_meta_all_key` is seen as `luckperms_meta` + `all_key`, instead of `luckperms_meta_all` + `key` like expected). Note that this worked before but was broken by a [restructuring made here 6 months ago](https://github.com/LuckPerms/placeholders/commit/9f5168a5b5a4e57396ebc0d841fdc2ce748f4f45).

`meta_all` even with this fix can still collide with meta keys starting with "all", so an unambiguous name like `all_meta` would be better, but that's out of scope for this fix PR