### PR TITLE
Tweak fabric-side text parsing to allow legacy (&x) formatting

### DIFF
--- a/fabric-placeholderapi/build.gradle
+++ b/fabric-placeholderapi/build.gradle
@@ -16,7 +16,7 @@ dependencies {
 
     implementation project(':common')
     shadow project(':common')
-    modImplementation include("eu.pb4:placeholder-api:2.0.0-beta.6+1.19")
+    modImplementation include("eu.pb4:placeholder-api:2.0.0-pre.1+1.19.2")
 }
 
 processResources {

--- a/fabric-placeholderapi/src/main/java/me/lucko/luckperms/placeholders/LuckPermsFabricPlaceholders.java
+++ b/fabric-placeholderapi/src/main/java/me/lucko/luckperms/placeholders/LuckPermsFabricPlaceholders.java
@@ -25,9 +25,12 @@
 
 package me.lucko.luckperms.placeholders;
 
+import eu.pb4.placeholders.api.ParserContext;
 import eu.pb4.placeholders.api.PlaceholderResult;
 import eu.pb4.placeholders.api.Placeholders;
 import eu.pb4.placeholders.api.TextParserUtils;
+import eu.pb4.placeholders.api.node.TextNode;
+import eu.pb4.placeholders.api.parsers.LegacyFormattingParser;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.luckperms.api.LuckPerms;
@@ -36,6 +39,7 @@ import net.luckperms.api.cacheddata.CachedDataManager;
 import net.luckperms.api.model.user.User;
 import net.luckperms.api.query.QueryOptions;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 
 import java.util.Map;
@@ -83,11 +87,15 @@ public class LuckPermsFabricPlaceholders implements ModInitializer, PlaceholderP
                         result = this.formatBoolean((boolean) result);
                     }
 
-                    return result == null ? PlaceholderResult.invalid() : PlaceholderResult.value(TextParserUtils.formatText(result.toString()));
+                    return result == null ? PlaceholderResult.invalid() : PlaceholderResult.value(parseText(result.toString()));
                 } else {
                     return PlaceholderResult.invalid("No player!");
                 }
             });
         });
+    }
+
+    private Text parseText(String input) {
+        return TextNode.asSingle(LegacyFormattingParser.ALL.parseNodes(TextParserUtils.formatNodes(input))).toText(ParserContext.of(), true);
     }
 }

--- a/fabric-placeholderapi/src/main/resources/fabric.mod.json
+++ b/fabric-placeholderapi/src/main/resources/fabric.mod.json
@@ -21,7 +21,8 @@
   },
   "depends": {
     "fabricloader": ">=0.7.4",
-    "minecraft": ">=1.19",
+    "minecraft": ">=1.19.2",
+    "placeholder-api": ">=2.0.0-pre.1+1.19.2",
     "luckperms": "*"
   }
 }


### PR DESCRIPTION
Adds extra parsing step to allow legacy (&x) formatting to work with placeholders. A lot of people complained about that on my discord (through it required change here), so here is the pr. It shouldn't effect people using non-legacy one.