### PR TITLE
feat(placeholder): add dynamic group weight calculation for user nodes

### DIFF
--- a/common/src/main/java/me/lucko/luckperms/placeholders/LPPlaceholderProvider.java
+++ b/common/src/main/java/me/lucko/luckperms/placeholders/LPPlaceholderProvider.java
@@ -399,6 +399,20 @@ public class LPPlaceholderProvider implements PlaceholderProvider {
                         .map(this::formatDuration)
                         .orElse("")
         );
+
+        builder.addDynamic("group_weight", (player, user, userData, queryOptions, groupName) ->
+                user.getNodes(NodeType.INHERITANCE).stream()
+                        .filter(n -> queryOptions.satisfies(n.getContexts()))
+                        .map(InheritanceNode::getGroupName)
+                        .filter(n -> n.equalsIgnoreCase(groupName))
+                        .map(n -> this.luckPerms.getGroupManager().getGroup(n))
+                        .filter(Objects::nonNull)
+                        .map(Group::getWeight)
+                        .filter(OptionalInt::isPresent)
+                        .mapToInt(OptionalInt::getAsInt)
+                        .findFirst()
+                        .orElse(0)
+        );
     }
 
     @Override


### PR DESCRIPTION
Add dynamic group weight calculation for user nodes
Usage: `%luckperms_group_weight_<group>%`

The difference between `%luckperms_meta_weight%` (which returns weight from the `primary group`) and the new placeholder is, that we can actually define the group we want to get the weight from.

<img width="844" height="342" alt="image" src="https://github.com/user-attachments/assets/d0d721bf-db53-4604-802b-4788258f735a" />